### PR TITLE
Add brief introduction to the project on organization repo (#3)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,22 @@
 # The Space ROS Organization
+
+<img src="https://github.com/space-ros/space-ros/blob/985f465ad0ff484c9d589e22d4628bde81b38661/logos/spaceros_white_on_blue.png" alt="Space ROS Logo - White on Blue" width="400"/>
+
+This is the home of Space ROS development.
+
+<p align="justify">
+Space ROS is an open-source software framework, derived from ROS 2, that will be hardened to be compatible with the demands of safety-critical space robotics applications.
+Conforming to the ROS 2 Application Programming Interface (API), Space ROS is designed to be platform independent, portable, and project independent.
+Space ROS will provide a robust framework for space robotics applications where ROS 2 applications can be reused with little to no modification, enabling the space community to take advantage of the innovation of the ROS community.
+This will shorten the time for development of novel space robotics capabilities, enable reuse of capabilities between missions, and lower the life-cycle cost of new space robotics missions.
+</p>
+<p align="justify">
+The Space ROS project started with a joint agreement between Blue Origin and NASA.
+Space ROS is intended to be an open, community-driven effort and we welcome contributions and participation from other companies and organizations in the aerospace industry.
+</p>
+
+## Useful links
+- [SpaceROS website](https://space.ros.org/index.html)
+- [SpaceROS documentation (rolling)](https://space-ros.github.io/docs/rolling/index.html)
+- [ROS Website](https://www.ros.org/)
+- [ROS 2 Documentation (rolling)](http://docs.ros.org/en/rolling/)


### PR DESCRIPTION
Closes #3.

I think that there is a need to provide sort of introduction about the project here.

For example, in the 1st technical WG we got a nice breakdown of the various development challenges, pending tasks an so on and this may a place for developers for the "How to get started" things.

For example, what do you think about linking here https://github.com/orgs/space-ros/projects/3 giving a very simple explanation of the various categories? Or slack/discord/whatever link or useful contact? 

I took the text from [here](https://space-ros.github.io/docs/rolling/Introduction.html) just as a draft.

Fast preview link of proposed changes [HERE](https://github.com/space-ros/.github/blob/2f1204125e5ccca3a7171f477024842e06852fe7/profile/README.md).